### PR TITLE
Added provision to indicate data send mode (sync/async).

### DIFF
--- a/Encoder.cpp
+++ b/Encoder.cpp
@@ -76,7 +76,7 @@ void Encoder::getFrame(const std::string &inputSource, const bool encoded, const
   // After encoding, copy the data to the *framePtr and specify the size in the "size" variable.
 }
 
-void Encoder::setDataReceiveCallback(onDataReceiveHandler handler)
+bool Encoder::setDataReceiveCallback(onDataReceiveHandler handler)
 {
   // Returns data received from the camera encoder.
   // This function must be non-blocking.

--- a/Encoder.h
+++ b/Encoder.h
@@ -28,7 +28,7 @@ public:
 
   void getFrame(const std::string &inputSource, const bool encoded, const MediaType mediaType, void *framePtr, long &size, time_t& timestamp);
 
-  void setDataReceiveCallback(onDataReceiveHandler handler);
+  bool setDataReceiveCallback(onDataReceiveHandler handler);
 
   void requestIntraFrame(const std::string &inputSource, const bool encoded);
 

--- a/MediaService.h
+++ b/MediaService.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <functional>
 
 namespace com {
 namespace anyconnect {
@@ -242,7 +243,10 @@ public:
   ///
   /// \param[in] onDataReceiveHandler - Handler function for the encoded data.
   ///
-  virtual void setDataReceiveCallback(onDataReceiveHandler handler) = 0;
+  /// \return True when encoder will send data asynchronously through the given callback
+  ///         False if encoder will send data synchronously through 'getFrame()' API.
+  ///
+  virtual bool setDataReceiveCallback(onDataReceiveHandler handler) = 0;
 
   ///
   /// Requests an I-Frame (with PPS and SPS).


### PR DESCRIPTION
Now client code will know in which mode the encoder will work by invoking the 'setDataReceiveCallback()' API.
When this API returns TRUE, meaning that encoder will send data in async mode using the provided callback. If return FALSE, it indicates that encoder will send data synchronously through 'getFrame()' API.